### PR TITLE
[Refactor] #13 : Accompanist Permissions → Moko Permissions 마이그레이션

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,7 +97,8 @@ dependencies {
     implementation(libs.coil.network.ktor3)
 
     // Permissions
-    implementation(libs.accompanist.permissions)
+    implementation(libs.moko.permissions)
+    implementation(libs.moko.permissions.compose)
 
     // Google Map
     implementation(libs.play.services.location)

--- a/app/src/main/java/com/ganaljigi/kubf/feature/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/home/screen/HomeScreen.kt
@@ -114,6 +114,7 @@ fun HomeScreen(
     var shouldShowRationale by remember { mutableStateOf(false) }
     var openAppSettingsDialog by remember { mutableStateOf(false) }
 
+    // 첫 진입 시 1회만 권한 요청 (거부해도 다이얼로그 없이 넘어감)
     LaunchedEffect(Unit) {
         val isGranted = permissionsController.isPermissionGranted(Permission.LOCATION)
         if (isGranted) {
@@ -122,10 +123,10 @@ fun HomeScreen(
             try {
                 permissionsController.providePermission(Permission.LOCATION)
                 isLocationPermissionGranted = true
-            } catch (e: DeniedAlwaysException) {
-                openAppSettingsDialog = true
-            } catch (e: DeniedException) {
-                shouldShowRationale = true
+            } catch (_: DeniedAlwaysException) {
+                // 첫 진입 시에는 다이얼로그 표시하지 않음
+            } catch (_: DeniedException) {
+                // 첫 진입 시에는 다이얼로그 표시하지 않음
             }
         }
     }

--- a/app/src/main/java/com/ganaljigi/kubf/feature/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/home/screen/HomeScreen.kt
@@ -1,11 +1,7 @@
 package com.ganaljigi.kubf.feature.home.screen
 
-import android.Manifest
 import android.app.Activity
-import android.content.pm.PackageManager
 import androidx.activity.compose.BackHandler
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
@@ -46,13 +42,14 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
-import org.koin.androidx.compose.koinViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ganalijigi.kubf.R
 import com.ganaljigi.kubf.core.designsystem.component.PermissionDialog
+import com.ganaljigi.kubf.core.designsystem.theme.Black
+import com.ganaljigi.kubf.core.designsystem.theme.Gray2
+import com.ganaljigi.kubf.core.designsystem.theme.KUBFAndroidTheme
 import com.ganaljigi.kubf.core.model.SearchMode
+import com.ganaljigi.kubf.core.ui.util.noRippleClickable
 import com.ganaljigi.kubf.feature.home.component.BarrierFreeInfoChip
 import com.ganaljigi.kubf.feature.home.component.BarrierFreeInfoItem
 import com.ganaljigi.kubf.feature.home.component.FindWayButton
@@ -69,16 +66,19 @@ import com.ganaljigi.kubf.feature.home.component.search.HomeInquiryDialog
 import com.ganaljigi.kubf.feature.home.viewmodel.HomeBottomSheetType
 import com.ganaljigi.kubf.feature.home.viewmodel.HomeUiMode
 import com.ganaljigi.kubf.feature.home.viewmodel.HomeViewModel
-import com.ganaljigi.kubf.core.designsystem.theme.Black
-import com.ganaljigi.kubf.core.designsystem.theme.Gray2
-import com.ganaljigi.kubf.core.designsystem.theme.KUBFAndroidTheme
-import com.ganaljigi.kubf.core.ui.util.noRippleClickable
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.google.android.gms.maps.model.LatLng
+import dev.icerock.moko.permissions.DeniedAlwaysException
+import dev.icerock.moko.permissions.DeniedException
+import dev.icerock.moko.permissions.Permission
+import dev.icerock.moko.permissions.PermissionsController
+import dev.icerock.moko.permissions.compose.BindEffect
+import dev.icerock.moko.permissions.compose.rememberPermissionsControllerFactory
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -102,67 +102,50 @@ fun HomeScreen(
     val focusManager = LocalFocusManager.current
     val activity = LocalContext.current as Activity
     val context = LocalContext.current
+
+    // Moko Permissions
+    val permissionsControllerFactory = rememberPermissionsControllerFactory()
+    val permissionsController: PermissionsController = remember(permissionsControllerFactory) {
+        permissionsControllerFactory.createPermissionsController()
+    }
+    BindEffect(permissionsController)
+
     var isLocationPermissionGranted by remember { mutableStateOf(false) }
     var shouldShowRationale by remember { mutableStateOf(false) }
     var openAppSettingsDialog by remember { mutableStateOf(false) }
-    val locationPermissionResultLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestMultiplePermissions(),
-    ) { permissions ->
-        val fineLocationGranted = permissions[Manifest.permission.ACCESS_FINE_LOCATION] ?: false
-        val coarseLocationGranted = permissions[Manifest.permission.ACCESS_COARSE_LOCATION] ?: false
 
-        if (fineLocationGranted || coarseLocationGranted) {
-            isLocationPermissionGranted = true
-        } else {
-            if (ActivityCompat.shouldShowRequestPermissionRationale(
-                    activity,
-                    Manifest.permission.ACCESS_FINE_LOCATION,
-                ) ||
-                ActivityCompat.shouldShowRequestPermissionRationale(
-                    activity,
-                    Manifest.permission.ACCESS_COARSE_LOCATION,
-                )
-            ) {
-                shouldShowRationale = true
-            } else {
-                openAppSettingsDialog = true
-            }
-        }
-    }
     LaunchedEffect(Unit) {
-        val fineLocationGranted = ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.ACCESS_FINE_LOCATION,
-        ) == PackageManager.PERMISSION_GRANTED
-        val coarseLocationGranted = ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.ACCESS_COARSE_LOCATION,
-        ) == PackageManager.PERMISSION_GRANTED
-
-        if (fineLocationGranted || coarseLocationGranted) {
+        val isGranted = permissionsController.isPermissionGranted(Permission.LOCATION)
+        if (isGranted) {
             isLocationPermissionGranted = true
         } else {
-            locationPermissionResultLauncher.launch(
-                arrayOf(
-                    Manifest.permission.ACCESS_FINE_LOCATION,
-                    Manifest.permission.ACCESS_COARSE_LOCATION,
-                ),
-            )
+            try {
+                permissionsController.providePermission(Permission.LOCATION)
+                isLocationPermissionGranted = true
+            } catch (e: DeniedAlwaysException) {
+                openAppSettingsDialog = true
+            } catch (e: DeniedException) {
+                shouldShowRationale = true
+            }
         }
     }
 
     LaunchedEffect(isLocationPermissionGranted) {
         if (isLocationPermissionGranted) {
             val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)
-            fusedLocationClient.getCurrentLocation(
-                Priority.PRIORITY_HIGH_ACCURACY,
-                null,
-            ).addOnSuccessListener { location ->
-                location?.let {
-                    viewModel.updateUserLocation(
-                        LatLng(it.latitude, it.longitude),
-                    )
+            try {
+                fusedLocationClient.getCurrentLocation(
+                    Priority.PRIORITY_HIGH_ACCURACY,
+                    null,
+                ).addOnSuccessListener { location ->
+                    location?.let {
+                        viewModel.updateUserLocation(
+                            LatLng(it.latitude, it.longitude),
+                        )
+                    }
                 }
+            } catch (_: SecurityException) {
+                // Permission not granted
             }
         }
     }
@@ -301,7 +284,7 @@ fun HomeScreen(
             Box(
                 modifier = Modifier.align(Alignment.TopCenter),
             ) {
-                androidx.compose.animation.AnimatedVisibility(
+                AnimatedVisibility(
                     visible = uiState.homeUiMode == HomeUiMode.FIND_MODE || uiState.homeUiMode == HomeUiMode.ROUTE_MODE,
                     enter = slideInVertically(
                         initialOffsetY = { -it / 2 },
@@ -325,8 +308,7 @@ fun HomeScreen(
                         },
                     )
                 }
-//                if (uiState.homeUiMode == HomeUiMode.DEFAULT) {
-                androidx.compose.animation.AnimatedVisibility(
+                AnimatedVisibility(
                     visible = uiState.homeUiMode == HomeUiMode.DEFAULT ||
                         uiState.homeUiMode == HomeUiMode.BARRIER_FREE_SHOWN,
                     enter = slideInVertically(
@@ -403,7 +385,7 @@ fun HomeScreen(
             Box(
                 modifier = Modifier.align(Alignment.BottomCenter),
             ) {
-                androidx.compose.animation.AnimatedVisibility(
+                AnimatedVisibility(
                     visible = uiState.homeUiMode == HomeUiMode.BARRIER_FREE_SHOWN,
                     enter = slideInVertically(
                         initialOffsetY = { it / 2 },
@@ -422,7 +404,7 @@ fun HomeScreen(
             Box(
                 modifier = Modifier.align(Alignment.BottomCenter),
             ) {
-                androidx.compose.animation.AnimatedVisibility(
+                AnimatedVisibility(
                     visible = uiState.homeUiMode == HomeUiMode.DEFAULT,
                     enter = slideInVertically(
                         initialOffsetY = { it / 2 },
@@ -447,27 +429,35 @@ fun HomeScreen(
                             modifier = Modifier.padding(end = 40.dp),
                         ) {
                             MyLocationButton {
-                                if (isLocationPermissionGranted) {
-                                    val fusedLocationClient =
-                                        LocationServices.getFusedLocationProviderClient(context)
-                                    fusedLocationClient.getCurrentLocation(
-                                        Priority.PRIORITY_HIGH_ACCURACY,
-                                        null,
-                                    ).addOnSuccessListener { location ->
-                                        location?.let {
-                                            viewModel.updateUserLocation(
-                                                LatLng(it.latitude, it.longitude),
-                                            )
-                                            viewModel.moveToUserLocation()
+                                scope.launch {
+                                    if (isLocationPermissionGranted) {
+                                        val fusedLocationClient =
+                                            LocationServices.getFusedLocationProviderClient(context)
+                                        try {
+                                            fusedLocationClient.getCurrentLocation(
+                                                Priority.PRIORITY_HIGH_ACCURACY,
+                                                null,
+                                            ).addOnSuccessListener { location ->
+                                                location?.let {
+                                                    viewModel.updateUserLocation(
+                                                        LatLng(it.latitude, it.longitude),
+                                                    )
+                                                    viewModel.moveToUserLocation()
+                                                }
+                                            }
+                                        } catch (_: SecurityException) {
+                                            // Permission not granted
+                                        }
+                                    } else {
+                                        try {
+                                            permissionsController.providePermission(Permission.LOCATION)
+                                            isLocationPermissionGranted = true
+                                        } catch (e: DeniedAlwaysException) {
+                                            openAppSettingsDialog = true
+                                        } catch (e: DeniedException) {
+                                            shouldShowRationale = true
                                         }
                                     }
-                                } else {
-                                    locationPermissionResultLauncher.launch(
-                                        arrayOf(
-                                            Manifest.permission.ACCESS_FINE_LOCATION,
-                                            Manifest.permission.ACCESS_COARSE_LOCATION,
-                                        ),
-                                    )
                                 }
                             }
                             NoticeButton {
@@ -480,7 +470,7 @@ fun HomeScreen(
             Box(
                 modifier = Modifier.align(Alignment.BottomCenter),
             ) {
-                androidx.compose.animation.AnimatedVisibility(
+                AnimatedVisibility(
                     visible = uiState.homeUiMode == HomeUiMode.ROUTE_MODE,
                     enter = slideInVertically(
                         initialOffsetY = { it / 2 },
@@ -511,12 +501,16 @@ fun HomeScreen(
         onDismissOpenAppSettingsDialog = { openAppSettingsDialog = false },
         onRetryClick = {
             shouldShowRationale = false
-            locationPermissionResultLauncher.launch(
-                arrayOf(
-                    Manifest.permission.ACCESS_FINE_LOCATION,
-                    Manifest.permission.ACCESS_COARSE_LOCATION,
-                ),
-            )
+            scope.launch {
+                try {
+                    permissionsController.providePermission(Permission.LOCATION)
+                    isLocationPermissionGranted = true
+                } catch (e: DeniedAlwaysException) {
+                    openAppSettingsDialog = true
+                } catch (e: DeniedException) {
+                    shouldShowRationale = true
+                }
+            }
         },
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ koinAnnotations = "2.3.1"
 kotlinxSerializationJson = "1.8.0"
 playServicesLocation = "21.3.0"
 playServicesMaps = "19.2.0"
-accompanistPermissions = "0.37.3"
+mokoPermissions = "0.18.0"
 kotlinxCollectionsImmutable = "0.4.0"
 ktor = "3.0.3"
 crashlytics = "3.0.6"
@@ -27,7 +27,8 @@ detekt = "1.23.7"
 napier = "2.7.1"
 
 [libraries]
-accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
+moko-permissions = { module = "dev.icerock.moko:permissions", version.ref = "mokoPermissions" }
+moko-permissions-compose = { module = "dev.icerock.moko:permissions-compose", version.ref = "mokoPermissions" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
 coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coilCompose" }


### PR DESCRIPTION
## 🚀 이슈번호
- closed #13

## ✏️ 변경사항
- Accompanist Permissions 의존성 제거
- Moko Permissions 의존성 추가 (moko-permissions, moko-permissions-compose)
- HomeScreen 권한 로직을 Moko Permissions API로 변경
- PermissionsController 사용으로 KMP 호환성 확보

## 📷 스크린샷
N/A (권한 핸들링 라이브러리 변경)

## ✍️ 사용법
1. 앱 실행
2. 위치 권한 요청 동작 확인
3. 권한 거부 시 다이얼로그 표시 확인

## 🎸 기타
- KMP 전환을 위한 사전 작업
- 기존 PermissionDialog UI 컴포넌트는 그대로 유지