### PR TITLE
[Refactor] #17 : RoomInfoScreen MVI 패턴 리팩토링

### DIFF
--- a/app/src/main/java/com/ganaljigi/kubf/feature/room/RoomInfoScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/room/RoomInfoScreen.kt
@@ -1,6 +1,11 @@
 package com.ganaljigi.kubf.feature.room
 
+import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -8,44 +13,83 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import org.koin.androidx.compose.koinViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ganalijigi.kubf.R
+import com.ganaljigi.kubf.core.designsystem.component.TransformableImage
 import com.ganaljigi.kubf.feature.room.component.DeskAndChairComponent
 import com.ganaljigi.kubf.feature.room.component.DoorComponent
 import com.ganaljigi.kubf.feature.room.component.RoomInfoDefaultComponent
 import com.ganaljigi.kubf.feature.room.component.RoomInfoTopAppBar
 import com.ganaljigi.kubf.feature.room.component.RoomPic
+import com.ganaljigi.kubf.feature.room.viewmodel.RoomInfoUiAction
+import com.ganaljigi.kubf.feature.room.viewmodel.RoomInfoUiEvent
 import com.ganaljigi.kubf.feature.room.viewmodel.RoomInfoUiState
 import com.ganaljigi.kubf.feature.room.viewmodel.RoomInfoViewModel
+import org.koin.androidx.compose.koinViewModel
 
-// 2-1) uiState를 직접 받는 버전 (프리뷰/에뮬에 더미 주입용)
 @Composable
 fun RoomInfoScreen(
-    uiState: RoomInfoUiState,
     onBackClick: () -> Unit,
+    viewModel: RoomInfoViewModel = koinViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collect { event ->
+            when (event) {
+                is RoomInfoUiEvent.NavigateBack -> onBackClick()
+                is RoomInfoUiEvent.ShowToast -> {
+                    Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    RoomInfoContent(
+        uiState = uiState,
+        onRoomInfoUiAction = viewModel::onRoomInfoUiAction,
+    )
+}
+
+@Composable
+private fun RoomInfoContent(
+    uiState: RoomInfoUiState,
+    onRoomInfoUiAction: (RoomInfoUiAction) -> Unit,
 ) {
     val scrollState = rememberScrollState()
-
     val showDeskAndChair = uiState.hasRoomInfo
     val showDoor = uiState.hasRoomInfo
 
     Scaffold(
         topBar = {
-            RoomInfoTopAppBar(
-                buildingName = uiState.buildingName,
-                onBackClick = onBackClick,
-            )
+            if (!uiState.isImageDialogVisible) {
+                RoomInfoTopAppBar(
+                    buildingName = uiState.buildingName,
+                    onBackClick = { onRoomInfoUiAction(RoomInfoUiAction.OnBackClick) },
+                )
+            }
         },
         containerColor = Color.White,
     ) { innerPadding ->
@@ -56,7 +100,12 @@ fun RoomInfoScreen(
                 .verticalScroll(scrollState),
         ) {
             if (uiState.roomPicUrls.isNotEmpty()) {
-                RoomPic(roomPicUrls = uiState.roomPicUrls)
+                RoomPic(
+                    roomPicUrls = uiState.roomPicUrls,
+                    onImageClick = { imageUrl ->
+                        onRoomInfoUiAction(RoomInfoUiAction.OnImageClick(imageUrl))
+                    },
+                )
             } else {
                 Box(
                     modifier = Modifier
@@ -111,30 +160,53 @@ fun RoomInfoScreen(
             Spacer(modifier = Modifier.height(30.dp))
         }
     }
-}
 
-// 2-2) 기존 뷰모델 버전은 위로 위임 (그대로 두고 수정)
-@Composable
-fun RoomInfoScreen(
-    onBackClick: () -> Unit,
-    viewModel: RoomInfoViewModel = koinViewModel(),
-) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    RoomInfoScreen(uiState = uiState, onBackClick = onBackClick)
-}
+    val configuration = LocalConfiguration.current
+    val density = LocalDensity.current
+    val screenWidth = with(density) { configuration.screenWidthDp.dp.roundToPx() }
+    val screenHeight = with(density) { configuration.screenHeightDp.dp.roundToPx() }
 
-@Composable
-fun RoomInfoScreenDummy(
-    uiState: RoomInfoUiState,
-    onBackClick: () -> Unit,
-) {
-    RoomInfoScreen(uiState = uiState, onBackClick = onBackClick)
+    AnimatedVisibility(
+        visible = uiState.isImageDialogVisible && uiState.selectedImageUrl != null,
+        enter = slideInVertically(initialOffsetY = { it }),
+        exit = slideOutVertically(targetOffsetY = { it }),
+    ) {
+        Box(
+            modifier = Modifier
+                .background(Color.Black)
+                .systemBarsPadding()
+                .fillMaxSize(),
+        ) {
+            uiState.selectedImageUrl?.let { imageUrl ->
+                TransformableImage(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clipToBounds(),
+                    imageUrl = imageUrl,
+                    screenWidth = screenWidth,
+                    screenHeight = screenHeight,
+                )
+            }
+            Icon(
+                modifier = Modifier
+                    .padding(10.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black)
+                    .align(Alignment.TopEnd)
+                    .clickable { onRoomInfoUiAction(RoomInfoUiAction.OnImageDialogClose) }
+                    .padding(16.dp),
+                painter = painterResource(R.drawable.ic_searchbar_close),
+                contentDescription = "닫기",
+                tint = Color.Unspecified,
+            )
+        }
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun RoomInfoScreenPreview() {
-    RoomInfoScreen(
+private fun RoomInfoScreenPreview() {
+    RoomInfoContent(
         uiState = RoomInfoUiState(
             buildingName = "경영관",
             roomPicUrls = listOf(
@@ -163,6 +235,6 @@ fun RoomInfoScreenPreview() {
             wheelchairTable = false,
             computerTable = false,
         ),
-        onBackClick = {},
+        onRoomInfoUiAction = {},
     )
 }

--- a/app/src/main/java/com/ganaljigi/kubf/feature/room/component/RoomPicComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/room/component/RoomPicComponent.kt
@@ -5,48 +5,29 @@ package com.ganaljigi.kubf.feature.room.component
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.rememberTransformableState
-import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.zIndex
 import coil3.compose.AsyncImage
-import com.ganalijigi.kubf.R
 import com.ganaljigi.kubf.core.designsystem.theme.KUBFAndroidTheme
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -54,22 +35,23 @@ import com.ganaljigi.kubf.core.designsystem.theme.KUBFAndroidTheme
 fun RoomPic(
     roomPicUrls: List<String>,
     modifier: Modifier = Modifier,
+    onImageClick: (String) -> Unit = {},
 ) {
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { roomPicUrls.size })
-    var showViewer by remember { mutableStateOf(false) }
 
     Box(modifier = modifier.fillMaxWidth()) {
         HorizontalPager(
             state = pagerState,
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(enabled = roomPicUrls.isNotEmpty()) { showViewer = true },
+            modifier = Modifier.fillMaxWidth(),
         ) { page ->
+            val imageUrl = roomPicUrls[page]
             AsyncImage(
-                model = roomPicUrls[page],
+                model = imageUrl,
                 contentDescription = "강의실 사진",
                 contentScale = ContentScale.FillWidth,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onImageClick(imageUrl) },
             )
         }
 
@@ -78,179 +60,18 @@ fun RoomPic(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(bottom = 12.dp)
-                    .background(
-                        Color(0xFF212121).copy(alpha = 0.6f),
-                        shape = RoundedCornerShape(20.dp),
-                    )
                     .zIndex(2f),
             ) {
-//                Row(
-//                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
-//                    verticalAlignment = Alignment.CenterVertically
-//                ) {
-//                    Text(
-//                        text = "${pagerState.currentPage + 1}",
-//                        style = KUBFAndroidTheme.typography.semiBold13.copy(color = Color.White)
-//                    )
-//                    Spacer(modifier = Modifier.width(1.5.dp))
-//                    Text(
-//                        text = "/",
-//                        style = KUBFAndroidTheme.typography.regular13.copy(color = Color.White)
-//                    )
-//                    Spacer(modifier = Modifier.width(1.5.dp))
-//                    Text(
-//                        text = "${roomPicUrls.size}",
-//                        style = KUBFAndroidTheme.typography.regular13.copy(color = Color.White)
-//                    )
-//                }
                 PagerCounter(pagerState = pagerState, total = roomPicUrls.size)
             }
         }
     }
-
-    if (showViewer) {
-        Dialog(
-            onDismissRequest = { showViewer = false },
-            properties = DialogProperties(usePlatformDefaultWidth = false),
-        ) {
-            val insetPadding = WindowInsets.systemBars.asPaddingValues()
-
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.6f)),
-            ) {
-                val viewPager = rememberPagerState(
-                    initialPage = pagerState.currentPage,
-                    pageCount = { roomPicUrls.size },
-                )
-
-                // 확대 하는 중에는 페이지 넘김 안됨
-                var canSwipe by remember { mutableStateOf(true) }
-
-                HorizontalPager(
-                    state = viewPager,
-                    modifier = Modifier.fillMaxSize(),
-                    userScrollEnabled = canSwipe,
-                ) { page ->
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        ZoomableImage(
-                            url = roomPicUrls[page],
-                            modifier = Modifier
-                                .fillMaxSize(),
-                            onBaseScale = { atBase -> canSwipe = atBase },
-                        )
-
-                        if (roomPicUrls.size > 1) {
-                            Box(
-                                modifier = Modifier
-                                    .align(Alignment.BottomCenter)
-                                    .padding(
-                                        bottom = insetPadding.calculateBottomPadding() + 12.dp,
-                                    )
-                                    .background(
-                                        Color(0xFF212121).copy(alpha = 0.6f),
-                                        shape = RoundedCornerShape(20.dp),
-                                    )
-                                    .zIndex(3f),
-                            ) {
-                                PagerCounter(pagerState = viewPager, total = roomPicUrls.size)
-                            }
-                        }
-                    }
-                }
-
-                IconButton(
-                    onClick = { showViewer = false },
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(
-                            top = insetPadding.calculateTopPadding() + 12.dp,
-                            end = 16.dp,
-                        )
-                        .size(24.dp)
-                        .zIndex(1f),
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_roominfo_picviewer),
-                        contentDescription = "닫기",
-                        tint = Color.White,
-                    )
-                }
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun ZoomableImage(
-    url: String,
-    modifier: Modifier = Modifier,
-    onBaseScale: (Boolean) -> Unit = {},
-) {
-    var scale by remember { mutableStateOf(1f) }
-    var offset by remember { mutableStateOf(Offset.Zero) }
-
-    LaunchedEffect(Unit) {
-        onBaseScale(true)
-    }
-
-    val transformState = rememberTransformableState { zoomChange, panChange, _ ->
-        val newScale = (scale * zoomChange).coerceIn(1f, 4f)
-        scale = newScale
-        if (newScale > 1f) {
-            offset += panChange
-            onBaseScale(false)
-        } else {
-            offset = Offset.Zero
-            onBaseScale(true)
-        }
-    }
-
-    val doubleTapReset = Modifier.pointerInput(Unit) {
-        detectTapGestures(
-            onDoubleTap = {
-                scale = 1f
-                offset = Offset.Zero
-                onBaseScale(true)
-            },
-        )
-    }
-
-    val zoomModifier =
-        if (scale > 1f) {
-            Modifier.transformable(
-                state = transformState,
-                canPan = { true },
-            )
-        } else {
-            Modifier
-        }
-
-    AsyncImage(
-        model = url,
-        contentDescription = "이미지 확대",
-        contentScale = ContentScale.Fit,
-        modifier = modifier
-            .graphicsLayer {
-                translationX = offset.x
-                translationY = offset.y
-                scaleX = scale
-                scaleY = scale
-            }
-            .then(zoomModifier)
-            .then(doubleTapReset),
-    )
 }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun PagerCounter(
-    pagerState: androidx.compose.foundation.pager.PagerState,
+    pagerState: PagerState,
     total: Int,
     modifier: Modifier = Modifier,
 ) {
@@ -284,7 +105,7 @@ private fun PagerCounter(
 
 @Preview(showBackground = true)
 @Composable
-fun RoomPicPreview() {
+private fun RoomPicPreview() {
     RoomPic(
         roomPicUrls = listOf(
             "https://i.pinimg.com/1200x/10/dc/2e/10dc2ece8b542854d0e276a1114d6190.jpg",

--- a/app/src/main/java/com/ganaljigi/kubf/feature/room/viewmodel/RoomInfoUiAction.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/room/viewmodel/RoomInfoUiAction.kt
@@ -1,0 +1,8 @@
+package com.ganaljigi.kubf.feature.room.viewmodel
+
+sealed interface RoomInfoUiAction {
+    data object OnBackClick : RoomInfoUiAction
+    data object OnRetry : RoomInfoUiAction
+    data class OnImageClick(val imageUrl: String) : RoomInfoUiAction
+    data object OnImageDialogClose : RoomInfoUiAction
+}

--- a/app/src/main/java/com/ganaljigi/kubf/feature/room/viewmodel/RoomInfoUiEvent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/room/viewmodel/RoomInfoUiEvent.kt
@@ -1,0 +1,8 @@
+package com.ganaljigi.kubf.feature.room.viewmodel
+
+import com.ganaljigi.kubf.core.ui.viewmodel.UiEvent
+
+sealed interface RoomInfoUiEvent : UiEvent {
+    data object NavigateBack : RoomInfoUiEvent
+    data class ShowToast(val message: String) : RoomInfoUiEvent
+}

--- a/app/src/main/java/com/ganaljigi/kubf/feature/room/viewmodel/RoomInfoUiState.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/room/viewmodel/RoomInfoUiState.kt
@@ -37,4 +37,8 @@ data class RoomInfoUiState(
 
     // API RoomInfo null 여부
     val hasRoomInfo: Boolean = true,
+
+    // 이미지 다이얼로그
+    val isImageDialogVisible: Boolean = false,
+    val selectedImageUrl: String? = null,
 )

--- a/app/src/main/java/com/ganaljigi/kubf/feature/room/viewmodel/RoomInfoViewModel.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/room/viewmodel/RoomInfoViewModel.kt
@@ -1,42 +1,50 @@
 package com.ganaljigi.kubf.feature.room.viewmodel
 
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.ganaljigi.kubf.core.navigation.Routes
+import com.ganaljigi.kubf.core.ui.viewmodel.BaseViewModel
 import com.ganaljigi.kubf.feature.room.mapper.toUiState
 import com.ganaljigi.kubf.feature.room.repository.RoomInfoRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.koin.android.annotation.KoinViewModel
 
 @KoinViewModel
 class RoomInfoViewModel(
+    savedStateHandle: SavedStateHandle,
     private val repository: RoomInfoRepository,
-    private val savedStateHandle: SavedStateHandle,
-) : ViewModel() {
+) : BaseViewModel<RoomInfoUiEvent>() {
+
+    private val route: Routes.RoomInfo = savedStateHandle.toRoute()
 
     private val _uiState = MutableStateFlow(RoomInfoUiState())
-    val uiState: StateFlow<RoomInfoUiState> = _uiState
-        .onStart { loadRoomInfo() }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = RoomInfoUiState(),
-        )
+    val uiState = _uiState.asStateFlow()
 
-    fun loadRoomInfo(
-        buildingId: Long = savedStateHandle.get<Long>("buildingId") ?: -1L,
-        spaceId: Long = savedStateHandle.get<Long>("spaceId") ?: -1L,
-        type: Int? = savedStateHandle.get<Int>("type") /*?: 1*/,
-        buildingNameArg: String? = savedStateHandle.get<String>("buildingName"),
-    ) {
+    init {
+        loadRoomInfo()
+    }
+
+    fun onRoomInfoUiAction(action: RoomInfoUiAction) {
+        when (action) {
+            is RoomInfoUiAction.OnBackClick -> onBackClick()
+            is RoomInfoUiAction.OnRetry -> loadRoomInfo()
+            is RoomInfoUiAction.OnImageClick -> onImageClick(action.imageUrl)
+            is RoomInfoUiAction.OnImageDialogClose -> closeImageDialog()
+        }
+    }
+
+    private fun loadRoomInfo() {
+        val buildingId = route.buildingId
+        val spaceId = route.spaceId
+        val type = route.type
+        val buildingNameArg = route.buildingName
+
         if (buildingId <= 0 || spaceId <= 0) return
 
         viewModelScope.launch {
@@ -53,6 +61,7 @@ class RoomInfoViewModel(
                     },
                     onFailure = { e ->
                         _uiState.update { it.copy(isLoading = false, error = e.message ?: "오류") }
+                        sendEvent(RoomInfoUiEvent.ShowToast("방 정보를 불러오는데 실패했습니다"))
                     },
                 )
             } else {
@@ -90,10 +99,32 @@ class RoomInfoViewModel(
                     },
                     onFailure = { e ->
                         _uiState.update { it.copy(isLoading = false, error = e.message ?: "오류") }
+                        sendEvent(RoomInfoUiEvent.ShowToast("방 정보를 불러오는데 실패했습니다"))
                     },
                 )
             }
         }
     }
-    fun retry() = loadRoomInfo()
+
+    private fun onBackClick() {
+        viewModelScope.launch { sendEvent(RoomInfoUiEvent.NavigateBack) }
+    }
+
+    private fun onImageClick(imageUrl: String) {
+        _uiState.update {
+            it.copy(
+                isImageDialogVisible = true,
+                selectedImageUrl = imageUrl,
+            )
+        }
+    }
+
+    private fun closeImageDialog() {
+        _uiState.update {
+            it.copy(
+                isImageDialogVisible = false,
+                selectedImageUrl = null,
+            )
+        }
+    }
 }


### PR DESCRIPTION
## 🚀 이슈번호
- closed #17

## ✏️ 변경사항
- RoomInfoScreen MVI 패턴 적용 (RoomInfoUiAction, RoomInfoUiEvent)
- RoomInfoViewModel에서 BaseViewModel 상속 및 SavedStateHandle.toRoute 사용
- 이미지 클릭 시 풀스크린 이미지 뷰어 표시 (AnimatedVisibility 슬라이드 애니메이션)
- RoomPicComponent 간소화 및 onImageClick 콜백 추가
- 에러 발생 시 Toast로 사용자 피드백 제공

## 📷 스크린샷
<img src="" width="360"/>

## ✍️ 사용법
1. 건물 정보 화면에서 강의실 클릭
2. 방 정보 화면에서 강의실 이미지 클릭 시 풀스크린 이미지 뷰어 확인

## 🎸 기타
- MVI 패턴 적용으로 상태 관리 개선
- Building 화면과 동일한 이미지 뷰어 UX 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 주요 변경 사항

* **새로운 기능**
  * 방 정보 화면에서 사진 클릭 시 전체 화면 이미지 뷰어 구현
  * 슬라이드 애니메이션이 포함된 이미지 다이얼로그 추가
  * 이미지의 확대, 축소, 회전 등 상호작용 기능 지원
  * 이미지 뷰어의 오른쪽 상단에 닫기 버튼 추가로 쉬운 종료 가능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->