### PR TITLE
[Refactor] #18 : Helper 화면 MVI 패턴 리팩토링

### DIFF
--- a/app/src/main/java/com/ganaljigi/kubf/feature/helper/component/information/InformationComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/helper/component/information/InformationComponent.kt
@@ -356,19 +356,19 @@ private fun PhoneActionText(
 
 @Preview(showBackground = true)
 @Composable
-fun InformationTitlePreview() {
+private fun InformationTitlePreview() {
     InformationTitle()
 }
 
 @Preview(showBackground = true)
 @Composable
-fun MapBoxPreview() {
+private fun MapBoxPreview() {
     MapBox()
 }
 
 @Preview(showBackground = true)
 @Composable
-fun InfoItemBoxPreview() {
+private fun InfoItemBoxPreview() {
     InfoItemBox(
         iconResId = R.drawable.ic_helper_phone,
         label = "전화번호",
@@ -384,6 +384,6 @@ fun InfoItemBoxPreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun InfoBoxPreview() {
+private fun InfoBoxPreview() {
     InfoBox()
 }

--- a/app/src/main/java/com/ganaljigi/kubf/feature/helper/component/notice/NoticeComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/helper/component/notice/NoticeComponent.kt
@@ -97,6 +97,30 @@ fun NoticeItem(
 
 @Preview(showBackground = true)
 @Composable
-fun NoticeBoxPreview() {
+private fun NoticeTitlePreview() {
     NoticeTitle()
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NoticeItemPreview() {
+    NoticeItem(
+        title = "[KIRD] 포용성장사업_이공계 장애 대학(원)생 경력개발 멘토링 모집 홍보",
+        date = "2025.05.13",
+        number = 47,
+        index = 0,
+        onClick = {},
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NoticeItemOddPreview() {
+    NoticeItem(
+        title = "스텝업탐방캠프 2기 참여자 모집",
+        date = "2025.05.13",
+        number = 46,
+        index = 1,
+        onClick = {},
+    )
 }

--- a/app/src/main/java/com/ganaljigi/kubf/feature/helper/component/shortcut/ShortCutComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/helper/component/shortcut/ShortCutComponent.kt
@@ -130,6 +130,26 @@ fun ShortCutItem(
 
 @Preview(showBackground = true)
 @Composable
-fun PreviewShortCutTitle() {
+private fun ShortCutTitlePreview() {
     ShortCutTitle()
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ShortCutItemPreview() {
+    ShortCutItem(
+        text = "장애학생 도우미",
+        iconResId = R.drawable.ic_helper_disablestudenthelper,
+        onClick = {},
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ShortCutItemNoIconPreview() {
+    ShortCutItem(
+        text = "기본 아이콘 항목",
+        iconResId = null,
+        onClick = {},
+    )
 }

--- a/app/src/main/java/com/ganaljigi/kubf/feature/helper/screen/HelperScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/helper/screen/HelperScreen.kt
@@ -1,5 +1,6 @@
 package com.ganaljigi.kubf.feature.helper.screen
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -7,16 +8,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.runtime.getValue
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
-import org.koin.androidx.compose.koinViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ganalijigi.kubf.R
 import com.ganaljigi.kubf.feature.helper.component.information.InfoBox
@@ -26,21 +28,56 @@ import com.ganaljigi.kubf.feature.helper.component.notice.NoticeTitle
 import com.ganaljigi.kubf.feature.helper.component.shortcut.ShortCutItem
 import com.ganaljigi.kubf.feature.helper.component.shortcut.ShortCutTitle
 import com.ganaljigi.kubf.feature.helper.component.topappbar.HelperTopAppBar
+import com.ganaljigi.kubf.feature.helper.viewmodel.HelperUiAction
+import com.ganaljigi.kubf.feature.helper.viewmodel.HelperUiEvent
+import com.ganaljigi.kubf.feature.helper.viewmodel.HelperUiState
 import com.ganaljigi.kubf.feature.helper.viewmodel.HelperViewModel
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun HelperScreen(
     onBackClick: () -> Unit,
-    navigateToDisableStudentHelper: () -> Unit = {},
-    navigateToSupport: () -> Unit = {},
-    navigateToJobInformation: () -> Unit = {},
-    vm: HelperViewModel = koinViewModel(),
+    navigateToDisableStudentHelper: () -> Unit,
+    navigateToSupport: () -> Unit,
+    navigateToJobInformation: () -> Unit,
+    viewModel: HelperViewModel = koinViewModel(),
 ) {
-    val state by vm.uiState.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
 
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collect { event ->
+            when (event) {
+                is HelperUiEvent.NavigateBack -> onBackClick()
+                is HelperUiEvent.NavigateToDisableStudentHelper -> navigateToDisableStudentHelper()
+                is HelperUiEvent.NavigateToSupport -> navigateToSupport()
+                is HelperUiEvent.NavigateToJobInformation -> navigateToJobInformation()
+                is HelperUiEvent.OpenUrl -> uriHandler.openUri(event.url)
+                is HelperUiEvent.ShowToast -> {
+                    Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    HelperContent(
+        uiState = uiState,
+        onHelperUiAction = viewModel::onHelperUiAction,
+    )
+}
+
+@Composable
+private fun HelperContent(
+    uiState: HelperUiState,
+    onHelperUiAction: (HelperUiAction) -> Unit,
+) {
     Scaffold(
-        topBar = { HelperTopAppBar(onBackClick = onBackClick) },
+        topBar = {
+            HelperTopAppBar(
+                onBackClick = { onHelperUiAction(HelperUiAction.OnBackClick) },
+            )
+        },
         containerColor = Color.White,
     ) { paddingValues ->
         Column(
@@ -48,45 +85,25 @@ fun HelperScreen(
                 .padding(paddingValues)
                 .verticalScroll(rememberScrollState()),
         ) {
-            // 공지사항
-
             NoticeTitle()
-//            NoticeItem(
-//                title = "[KIRD] 포용성장사업_이공계 장애 대학(원)생 경력개발 멘토링 모집 홍보 새글",
-//                date = "2025.05.13",
-//                number = 47,
-//                index = 0
-//            )
-//            NoticeItem(
-//                title = "스텝업탐방캠프 2기 참여자 모집",
-//                date = "2025.05.13",
-//                number = 46,
-//                index = 1
-//            )
-//            NoticeItem(
-//                title = "2025 동행, 국가유산 ‘빛나는 우리를 만나다’「마음으로 듣는 국가유산」 역사 기행 참여 안내 새글",
-//                date = "2025.05.13",
-//                number = 45,
-//                index = 2
-//            )
 
             when {
-                state.isLoading -> {
+                uiState.isLoading -> {
                     CircularProgressIndicator(Modifier.padding(16.dp))
                 }
-                state.error != null -> {
+                uiState.error != null -> {
                     Column(Modifier.padding(16.dp)) {
-                        Text(text = state.error ?: "공지사항을 찾을 수 없습니다.")
+                        Text(text = uiState.error ?: "공지사항을 찾을 수 없습니다.")
                     }
                 }
                 else -> {
-                    state.notices.forEachIndexed { index, n ->
+                    uiState.notices.forEachIndexed { index, notice ->
                         NoticeItem(
-                            title = n.title,
-                            date = n.date,
-                            number = n.displayNumber,
+                            title = notice.title,
+                            date = notice.date,
+                            number = notice.displayNumber,
                             index = index,
-                            onClick = { uriHandler.openUri(n.url) },
+                            onClick = { onHelperUiAction(HelperUiAction.OnNoticeClick(notice.url)) },
                         )
                     }
                 }
@@ -94,32 +111,29 @@ fun HelperScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // 바로가기
             ShortCutTitle()
             Column(
                 verticalArrangement = Arrangement.spacedBy(12.dp),
-                modifier = Modifier,
             ) {
                 ShortCutItem(
                     text = "장애학생 도우미",
                     iconResId = R.drawable.ic_helper_disablestudenthelper,
-                    onClick = navigateToDisableStudentHelper,
+                    onClick = { onHelperUiAction(HelperUiAction.OnDisableStudentHelperClick) },
                 )
                 ShortCutItem(
                     text = "지원 업무",
                     iconResId = R.drawable.ic_helper_support,
-                    onClick = navigateToSupport,
+                    onClick = { onHelperUiAction(HelperUiAction.OnSupportClick) },
                 )
                 ShortCutItem(
                     text = "채용 정보",
                     iconResId = R.drawable.ic_helper_jobinformation,
-                    onClick = navigateToJobInformation,
+                    onClick = { onHelperUiAction(HelperUiAction.OnJobInformationClick) },
                 )
             }
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // 정보
             InformationTitle()
             InfoBox()
 
@@ -127,9 +141,3 @@ fun HelperScreen(
         }
     }
 }
-
-// @Preview (showBackground = true)
-// @Composable
-// fun HelperScreenPreview() {
-//    HelperScreen {  }
-// }

--- a/app/src/main/java/com/ganaljigi/kubf/feature/helper/screen/HelperScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/helper/screen/HelperScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ganalijigi.kubf.R
@@ -32,6 +33,7 @@ import com.ganaljigi.kubf.feature.helper.viewmodel.HelperUiAction
 import com.ganaljigi.kubf.feature.helper.viewmodel.HelperUiEvent
 import com.ganaljigi.kubf.feature.helper.viewmodel.HelperUiState
 import com.ganaljigi.kubf.feature.helper.viewmodel.HelperViewModel
+import com.ganaljigi.kubf.feature.helper.viewmodel.NoticeUi
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -140,4 +142,52 @@ private fun HelperContent(
             Spacer(modifier = Modifier.height(16.dp))
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HelperContentPreview() {
+    HelperContent(
+        uiState = HelperUiState(
+            notices = listOf(
+                NoticeUi(
+                    title = "[KIRD] 포용성장사업_이공계 장애 대학(원)생 경력개발 멘토링 모집 홍보",
+                    date = "2025.05.13",
+                    url = "",
+                    displayNumber = 47,
+                ),
+                NoticeUi(
+                    title = "스텝업탐방캠프 2기 참여자 모집",
+                    date = "2025.05.13",
+                    url = "",
+                    displayNumber = 46,
+                ),
+                NoticeUi(
+                    title = "2025 동행, 국가유산 '빛나는 우리를 만나다' 역사 기행 참여 안내",
+                    date = "2025.05.13",
+                    url = "",
+                    displayNumber = 45,
+                ),
+            ),
+        ),
+        onHelperUiAction = {},
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HelperContentLoadingPreview() {
+    HelperContent(
+        uiState = HelperUiState(isLoading = true),
+        onHelperUiAction = {},
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HelperContentErrorPreview() {
+    HelperContent(
+        uiState = HelperUiState(error = "공지사항을 불러오는데 실패했습니다."),
+        onHelperUiAction = {},
+    )
 }

--- a/app/src/main/java/com/ganaljigi/kubf/feature/helper/viewmodel/HelperUiAction.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/helper/viewmodel/HelperUiAction.kt
@@ -1,0 +1,10 @@
+package com.ganaljigi.kubf.feature.helper.viewmodel
+
+sealed interface HelperUiAction {
+    data object OnBackClick : HelperUiAction
+    data object OnRetry : HelperUiAction
+    data class OnNoticeClick(val url: String) : HelperUiAction
+    data object OnDisableStudentHelperClick : HelperUiAction
+    data object OnSupportClick : HelperUiAction
+    data object OnJobInformationClick : HelperUiAction
+}

--- a/app/src/main/java/com/ganaljigi/kubf/feature/helper/viewmodel/HelperUiEvent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/helper/viewmodel/HelperUiEvent.kt
@@ -1,0 +1,12 @@
+package com.ganaljigi.kubf.feature.helper.viewmodel
+
+import com.ganaljigi.kubf.core.ui.viewmodel.UiEvent
+
+sealed interface HelperUiEvent : UiEvent {
+    data object NavigateBack : HelperUiEvent
+    data object NavigateToDisableStudentHelper : HelperUiEvent
+    data object NavigateToSupport : HelperUiEvent
+    data object NavigateToJobInformation : HelperUiEvent
+    data class OpenUrl(val url: String) : HelperUiEvent
+    data class ShowToast(val message: String) : HelperUiEvent
+}

--- a/app/src/main/java/com/ganaljigi/kubf/feature/helper/viewmodel/HelperViewModel.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/helper/viewmodel/HelperViewModel.kt
@@ -1,14 +1,11 @@
 package com.ganaljigi.kubf.feature.helper.viewmodel
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ganaljigi.kubf.core.ui.viewmodel.BaseViewModel
 import com.ganaljigi.kubf.feature.helper.mapper.toUiState
 import com.ganaljigi.kubf.feature.helper.repository.HelperRepository
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.koin.android.annotation.KoinViewModel
@@ -19,31 +16,34 @@ import java.util.Locale
 @KoinViewModel
 class HelperViewModel(
     private val repository: HelperRepository,
-) : ViewModel() {
+) : BaseViewModel<HelperUiEvent>() {
 
     private val _uiState = MutableStateFlow(HelperUiState())
-    val uiState: StateFlow<HelperUiState> = _uiState
-        .onStart { loadNotices() }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = HelperUiState(),
-        )
+    val uiState = _uiState.asStateFlow()
 
     private val dateFmt = DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.KOREA)
-    private fun String.toLocalDateOrMin(): LocalDate =
-        runCatching { LocalDate.parse(this, dateFmt) }.getOrElse { LocalDate.MIN }
 
-    fun loadNotices() {
+    init {
+        loadNotices()
+    }
+
+    fun onHelperUiAction(action: HelperUiAction) {
+        when (action) {
+            is HelperUiAction.OnBackClick -> onBackClick()
+            is HelperUiAction.OnRetry -> loadNotices()
+            is HelperUiAction.OnNoticeClick -> onNoticeClick(action.url)
+            is HelperUiAction.OnDisableStudentHelperClick -> onDisableStudentHelperClick()
+            is HelperUiAction.OnSupportClick -> onSupportClick()
+            is HelperUiAction.OnJobInformationClick -> onJobInformationClick()
+        }
+    }
+
+    private fun loadNotices() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             repository.fetchNotices().fold(
                 onSuccess = { dto ->
                     val mapped = dto.toUiState()
-
-                    val dateFmt = DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.KOREA)
-                    fun String.toLocalDateOrMin() =
-                        runCatching { LocalDate.parse(this, dateFmt) }.getOrElse { LocalDate.MIN }
 
                     val top3 = mapped.notices
                         .sortedByDescending { it.date.toLocalDateOrMin() }
@@ -56,10 +56,32 @@ class HelperViewModel(
                 },
                 onFailure = { e ->
                     _uiState.update { it.copy(isLoading = false, error = e.message ?: "") }
+                    sendEvent(HelperUiEvent.ShowToast("공지사항을 불러오는데 실패했습니다"))
                 },
             )
         }
     }
 
-    fun retry() = loadNotices()
+    private fun onBackClick() {
+        viewModelScope.launch { sendEvent(HelperUiEvent.NavigateBack) }
+    }
+
+    private fun onNoticeClick(url: String) {
+        viewModelScope.launch { sendEvent(HelperUiEvent.OpenUrl(url)) }
+    }
+
+    private fun onDisableStudentHelperClick() {
+        viewModelScope.launch { sendEvent(HelperUiEvent.NavigateToDisableStudentHelper) }
+    }
+
+    private fun onSupportClick() {
+        viewModelScope.launch { sendEvent(HelperUiEvent.NavigateToSupport) }
+    }
+
+    private fun onJobInformationClick() {
+        viewModelScope.launch { sendEvent(HelperUiEvent.NavigateToJobInformation) }
+    }
+
+    private fun String.toLocalDateOrMin(): LocalDate =
+        runCatching { LocalDate.parse(this, dateFmt) }.getOrElse { LocalDate.MIN }
 }

--- a/app/src/main/java/com/ganaljigi/kubf/feature/room/RoomInfoScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/room/RoomInfoScreen.kt
@@ -133,7 +133,7 @@ fun RoomInfoScreenDummy(
 
 @Preview(showBackground = true)
 @Composable
-fun RoomInfoScreenPreview() {
+private fun RoomInfoScreenPreview() {
     RoomInfoScreen(
         uiState = RoomInfoUiState(
             buildingName = "경영관",
@@ -162,6 +162,30 @@ fun RoomInfoScreenPreview() {
             wheelChair = true,
             wheelchairTable = false,
             computerTable = false,
+        ),
+        onBackClick = {},
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RoomInfoScreenNoPicPreview() {
+    RoomInfoScreen(
+        uiState = RoomInfoUiState(
+            buildingName = "과학관",
+            roomPicUrls = emptyList(),
+            frontDoor = true,
+            backDoor = true,
+            roomNumber = "301호",
+            roomName = "실험실",
+            lecture = false,
+            capacity = 20,
+            area = 45.0,
+            floorSpace = 13.6,
+            roomType = "평탄식",
+            department = "자연과학대학",
+            departmentNumber = "02-450-1234",
+            hasRoomInfo = true,
         ),
         onBackClick = {},
     )

--- a/app/src/main/java/com/ganaljigi/kubf/feature/room/component/DeskAndChairComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/room/component/DeskAndChairComponent.kt
@@ -103,7 +103,7 @@ fun DeskAndChairItem(
 
 @Preview(showBackground = true)
 @Composable
-fun DeskAndChairComponentPreview() {
+private fun DeskAndChairComponentPreview() {
     KUBFAndroidTheme {
         DeskAndChairComponent(
             allInOne = false,
@@ -117,5 +117,21 @@ fun DeskAndChairComponentPreview() {
             wheelchairTable = false,
             computerTable = false,
         )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DeskAndChairItemExistsPreview() {
+    KUBFAndroidTheme {
+        DeskAndChairItem(label = "1인용", exists = true)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DeskAndChairItemNotExistsPreview() {
+    KUBFAndroidTheme {
+        DeskAndChairItem(label = "1인용", exists = false)
     }
 }

--- a/app/src/main/java/com/ganaljigi/kubf/feature/room/component/DoorComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/room/component/DoorComponent.kt
@@ -73,8 +73,24 @@ fun DoorItem(
 
 @Preview(showBackground = true)
 @Composable
-fun DoorComponentPreview() {
+private fun DoorComponentPreview() {
     KUBFAndroidTheme {
         DoorComponent(frontDoor = true, backDoor = false)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DoorItemExistsPreview() {
+    KUBFAndroidTheme {
+        DoorItem(label = "앞문", exists = true)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DoorItemNotExistsPreview() {
+    KUBFAndroidTheme {
+        DoorItem(label = "뒷문", exists = false)
     }
 }

--- a/app/src/main/java/com/ganaljigi/kubf/feature/room/component/RoomInfoDefaultComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/room/component/RoomInfoDefaultComponent.kt
@@ -491,7 +491,7 @@ private fun copyToClipboard(ctx: Context, text: String) {
 
 @Preview(showBackground = true)
 @Composable
-fun RoomInfoDefaultComponentPreview() {
+private fun RoomInfoDefaultComponentPreview() {
     KUBFAndroidTheme {
         RoomInfoDefaultComponent(
             roomNumber = "102호",
@@ -510,26 +510,31 @@ fun RoomInfoDefaultComponentPreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun LectureChipPreview() {
+private fun RoomInfoDefaultComponentWithCommentPreview() {
+    KUBFAndroidTheme {
+        RoomInfoDefaultComponent(
+            roomNumber = "201호",
+            roomName = "대강의실",
+            lecture = false,
+            capacity = 100,
+            area = 120.5,
+            roomComment = "휠체어 진입 가능",
+            floorSpace = 36.5,
+            roomType = "계단식",
+            department = "교무처",
+            departmentNumber = "02-450-3968",
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LectureChipPreview() {
     LectureChip()
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun _IconDebugPreview() {
-    Box(
-        Modifier
-            .size(80.dp)
-            .background(Color.Yellow) // 뒤 배경 확실히
-            .padding(8.dp),
-    ) {
-        Icon(
-            painter = painterResource(R.drawable.ic_roominfo_capacity),
-            contentDescription = null,
-            tint = Color.Magenta, // 눈에 띄는 색
-            modifier = Modifier
-                .size(48.dp) // 크게
-                .align(Alignment.Center),
-        )
-    }
+private fun DepartmentPhoneRowPreview() {
+    DepartmentPhoneRow(departmentNumber = "02-450-3968")
 }

--- a/app/src/main/java/com/ganaljigi/kubf/feature/room/component/RoomPicComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/room/component/RoomPicComponent.kt
@@ -284,11 +284,21 @@ private fun PagerCounter(
 
 @Preview(showBackground = true)
 @Composable
-fun RoomPicPreview() {
+private fun RoomPicPreview() {
     RoomPic(
         roomPicUrls = listOf(
             "https://i.pinimg.com/1200x/10/dc/2e/10dc2ece8b542854d0e276a1114d6190.jpg",
             "https://i.pinimg.com/1200x/d9/5e/3f/d95e3f592893bd3df9e62df37c831638.jpg",
+        ),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RoomPicSinglePreview() {
+    RoomPic(
+        roomPicUrls = listOf(
+            "https://i.pinimg.com/1200x/10/dc/2e/10dc2ece8b542854d0e276a1114d6190.jpg",
         ),
     )
 }

--- a/app/src/main/java/com/ganaljigi/kubf/feature/room/component/TopAppBar.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/feature/room/component/TopAppBar.kt
@@ -62,7 +62,7 @@ fun RoomInfoTopAppBar(
 
 @Preview(showBackground = true)
 @Composable
-fun RoomInfoTopAppBarPreview() {
+private fun RoomInfoTopAppBarPreview() {
     KUBFAndroidTheme {
         RoomInfoTopAppBar(
             buildingName = "경영관",


### PR DESCRIPTION
## 🚀 이슈번호
- closed #18

## ✏️ 변경사항
### MVI 패턴 적용
- HelperUiAction.kt 신규 생성 (사용자 액션 정의)
- HelperUiEvent.kt 신규 생성 (일회성 이벤트 정의)
- HelperViewModel BaseViewModel 상속으로 변경
- HelperScreen LaunchedEffect로 uiEvent 수집
- onHelperUiAction 단일 진입점 패턴 적용
- 네비게이션 및 URL 오픈 로직 Event로 이동

### Preview 추가
- NoticeItem, ShortCutItem Preview 추가
- HelperScreen Content Preview 추가 (로딩, 에러, 정상 상태)
- RoomInfo 컴포넌트 Preview 추가 (DeskAndChairItem, DoorItem, DepartmentPhoneRow 등)
- Preview 함수 private 접근자 적용

## ✍️ 사용법
1. Helper 화면 진입
2. 공지사항 클릭 → URL 열기 확인
3. 바로가기 항목 클릭 → 화면 이동 확인
4. 뒤로가기 동작 확인

## 🎸 기타
- Home, Building, RoomInfo와 동일한 MVI 패턴 적용
- 모든 컴포넌트에 Preview 추가로 UI 개발 편의성 향상

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * Helper 화면을 이벤트 중심으로 재구성하여 네비게이션, URL 열기, 토스트 등 UI 흐름을 통합·중앙화했습니다.
  * 뷰모델과 화면 간 액션 처리 경로를 단일 진입점으로 정리했습니다.

* **신규 기능**
  * Helper UI 액션 및 이벤트 계약을 도입해 다양한 사용자 상호작용(뒤로가기, 재시도, 공지 클릭, 바로가기 등)을 명확히 표현합니다.

* **스타일/미세조정**
  * 여러 컴포저블 미리보기의 접근성을 private로 제한하고 미리보기 케이스를 추가해 디자인 검토를 강화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->